### PR TITLE
Create relations as last step

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -30,7 +30,7 @@ class Factory
     protected function withBaseBuilder($builder, $data, $quantity)
     {
         if($this->isBaseBuilder($builder)) {
-            return $builder::create($data, $quantity)->entities();
+            return $builder::create($data, $quantity)->get();
         }
 
         return null;


### PR DESCRIPTION
- Move quantity from create to get
- Now get must be called in order to create the instances
- The model class is set once the builder instance is created
- Add 'associate' method to store the related entity's id in data
- Add 'addMany' method to be able to attach many related entities or to define how many of them must be created